### PR TITLE
Use default rabbitmq values

### DIFF
--- a/src/examples/client.example.ts
+++ b/src/examples/client.example.ts
@@ -2,7 +2,7 @@
 import irisSetup from '..';
 
 const config = {
-  url: 'amqp://repositive:repositive@localhost:5672',
+  url: 'amqp://guest:guest@localhost:5672',
   exchange: 'test'
 };
 

--- a/src/examples/serving.example.ts
+++ b/src/examples/serving.example.ts
@@ -2,7 +2,7 @@
 import irisSetup from '..';
 
 const config = {
-  url: 'amqp://repositive:repositive@localhost:5672',
+  url: 'amqp://guest:guest@localhost:5672',
   exchange: 'test'
 };
 


### PR DESCRIPTION
I think its better for the example to use the default rabbitmq values for user and password