### PR TITLE
[F] Pause register message consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,25 @@ Iris is extensible through [Functional Composition](https://en.wikipedia.org/wik
 
 The following examples use [Ramda pipes](http://ramdajs.com/docs/#pipeP) but you are free to use or implement your own solution.
 
+## Handler Injection
+
+It's possible to inject properties in handlers. Iris provides a `inject` function to help with it:
+
+```ts
+import {inject, RegisterHandlerInput} from '@repositive/iris';
+import * as _fetch from 'node-fetch';
+
+interface CustomArgs {
+  _fetch: typeof fetch
+}
+
+async function handler({payload, _fetch}: RegisterHandlerInput & CustomArgs) {
+  return await _fetch(/*Implementation details*/)
+}
+
+const irisHandler = inject<CustomArgs, RegisterHandlerInput, Promise<any>>({args: {_fetch: fetch}, func: handler})
+```
+
 
 
 **Serialization:**

--- a/src/amqp/index.spec.ts
+++ b/src/amqp/index.spec.ts
@@ -143,7 +143,9 @@ test('Tests setup funcion' , (t: Test) => {
     on0.args[1]();
 
     await result.register({pattern: '', handler: spy()}).then(() => {
-      t.ok(true, 'Subscribe works on errored library');
+      t.notOk(true, 'Subscribe should reject on errored library');
+    }).catch(err => {
+      t.ok(true, 'Register rejects the promise on pipe broken');
     });
 
     await result.request({pattern: '', payload: Buffer.alloc(0)})

--- a/src/amqp/index.ts
+++ b/src/amqp/index.ts
@@ -3,7 +3,7 @@ import {SetupRegisterOpts, setupRegister} from './register';
 import {SetupRequestOpts, setupRequest} from './request';
 import {SetupEmitOpts, setupEmit} from './emit';
 import {RPCError} from '../errors';
-import {IrisBackend, RegisterInput, RequestInput, CollectInput, EmitInput} from '..';
+import {IrisBackend, RegisterActiveContext, RegisterInput, RequestInput, CollectInput, EmitInput} from '..';
 
 import {v4} from 'uuid';
 
@@ -120,13 +120,13 @@ export default async function setup(opts: LibOpts = defaults): Promise<IrisBacke
   }));
 
   return {
-    async register(ropts: RegisterInput<Buffer, Buffer>): Promise<void> {
+    async register(ropts: RegisterInput<Buffer, Buffer>): Promise<RegisterActiveContext> {
       const id = `${ropts.pattern}-${ropts.namespace || ''}`;
       if (!registrations[id]) {
         registrations[id] = ropts;
       }
       if (errored) {
-        return Promise.resolve();
+        return Promise.reject(new Error('Broken Pipe'));
       } else {
         return operations[1](ropts);
       }

--- a/src/amqp/register.spec.ts
+++ b/src/amqp/register.spec.ts
@@ -87,7 +87,7 @@ test('Everything goes well in register function', (t: Test) => {
     await consumer(message);
 
     t.ok(handler.calledOnce, 'The implemented function is called on message');
-    t.deepEquals(handler.getCall(0).args[0], {payload: message.content}, 'The implementation is called with the message content');
+    t.deepEquals(handler.getCall(0).args[0].payload, message.content, 'The implementation is called with the message content');
 
     t.ok(ch.publish.calledOnce, 'The library pipes the response to request service');
     const sendCall = ch.publish.getCall(0);

--- a/src/amqp/register.ts
+++ b/src/amqp/register.ts
@@ -1,11 +1,69 @@
 import {Channel, Message} from 'amqplib';
 import {all} from 'bluebird';
-import {RegisterInput} from '..';
+import {RegisterInput, RegisterHandler, RegisterActiveContext, RegisterPausedContext} from '..';
 
 export interface SetupRegisterOpts {
   ch: Channel;
   exchange: string;
   namespace?: string;
+}
+
+function _resume({
+  ch,
+  handler,
+  retry,
+  queueName,
+  _activeContext
+}: {
+  ch: Channel,
+  handler: RegisterHandler<Buffer, Buffer>,
+  retry: number,
+  queueName: string,
+  _activeContext: RegisterActiveContext
+}) {
+  return ch.consume(
+    queueName,
+    (msg: Message) => {
+      function onError(err?: Error) {
+        const currentRetry = msg.properties.headers.retry || 0;
+        if (currentRetry < retry) {
+          return ch.sendToQueue(
+            queueName,
+            msg.content,
+            {...msg.properties, headers: {...msg.properties.headers, retry: currentRetry + 1}}
+          );
+        } else if (msg.properties.correlationId) {
+          return ch.publish(
+            '',
+            msg.properties.replyTo,
+            Buffer.from(JSON.stringify({error: (err && err.message) || 'Unexpected error'})),
+            {correlationId: msg.properties.correlationId, headers: {code: 1}}
+          );
+        }
+      }
+      try {
+        return handler({payload: msg.content, context: _activeContext})
+          .then((response?: Buffer) => {
+            if (msg.properties && msg.properties.replyTo && msg.properties.correlationId) {
+              return ch.publish(
+                '',
+                msg.properties.replyTo,
+                response || Buffer.alloc(0),
+                {correlationId: msg.properties.correlationId, headers: {code: 0}}
+              );
+            }
+          })
+          .catch(onError)
+          .then(() => {
+            ch.ack(msg);
+          });
+      } catch(err) {
+        onError(err);
+        ch.ack(msg);
+      }
+    },
+    {noAck: false}
+  );
 }
 
 export async function setupRegister({
@@ -20,56 +78,55 @@ export async function setupRegister({
     pattern,
     handler,
     retry = 0
-  }: RegisterInput<Buffer, Buffer>): Promise<void> {
+  }: RegisterInput<Buffer, Buffer>): Promise<RegisterActiveContext> {
     const __namespace = arguments[0].namespace || namespace;
     const queueName = `${__namespace}-${pattern}`;
+
+    // _pause and _reg are equired to keep the pause function working without any object binding. Library users can thanks to this compose on top of pause without having to worry about the context of the function.
+    let _pause: () => Promise<RegisterPausedContext> = () => Promise.reject(new Error('Not yet initialized')) as any;
+    let _paused: false | Promise<RegisterPausedContext> = false;
+
+    const _activeContext: RegisterActiveContext = {
+      pause: () => {
+        if (!_paused) {
+          _paused = _pause();
+        }
+        return _paused;
+      }
+    };
+    Object.freeze(_activeContext);
+
+    const _pausedContext: RegisterPausedContext = {
+      resume: () => {
+        return _resume({ch, handler, retry, queueName, _activeContext})
+          .then(createContext)
+          .then((res) => {
+            _pause = res.pause;
+            _paused = false;
+            return _activeContext;
+          }) as any;
+      }
+    };
+    Object.freeze(_pausedContext);
+
+    const createContext = (r: any) => ({
+      async pause(time?: number): Promise<RegisterPausedContext> {
+        await ch.cancel(r.consumerTag);
+        return _pausedContext;
+      }
+    });
+
     return await all([
       ch.assertQueue(queueName),
       ch.prefetch(1),
       ch.bindQueue(queueName, exchange, pattern),
-      ch.consume(
-        queueName,
-        (msg: Message) => {
-          function onError(err?: Error) {
-            const currentRetry = msg.properties.headers.retry || 0;
-            if (currentRetry < retry) {
-              return ch.sendToQueue(
-                queueName,
-                msg.content,
-                {...msg.properties, headers: {...msg.properties.headers, retry: currentRetry + 1}}
-              );
-            } else if (msg.properties.correlationId) {
-              return ch.publish(
-                '',
-                msg.properties.replyTo,
-                Buffer.from(JSON.stringify({error: (err && err.message) || 'Unexpected error'})),
-                {correlationId: msg.properties.correlationId, headers: {code: 1}}
-              );
-            }
-          }
-          try {
-            return handler({payload: msg.content})
-              .then((response?: Buffer) => {
-                if (msg.properties && msg.properties.replyTo && msg.properties.correlationId) {
-                  return ch.publish(
-                    '',
-                    msg.properties.replyTo,
-                    response || Buffer.alloc(0),
-                    {correlationId: msg.properties.correlationId, headers: {code: 0}}
-                  );
-                }
-              })
-              .catch(onError)
-              .then(() => {
-                ch.ack(msg);
-              });
-          } catch(err) {
-            onError(err);
-            ch.ack(msg);
-          }
-        },
-        {noAck: false}
-      )
-    ]).then(_ => undefined);
+      _resume({ch, handler, retry, queueName, _activeContext})
+    ])
+    .then(([q, p, b, r]) => r)
+    .then(createContext)
+    .then((res) => {
+      _pause = res.pause;
+      return _activeContext;
+    });
   };
 }

--- a/src/examples/chat.example.ts
+++ b/src/examples/chat.example.ts
@@ -26,13 +26,13 @@ interface Msg {
   comment: string;
 }
 
-async function chatListener({payload}: {payload: any}): Promise<any> {
+async function chatListener({payload}: {payload?: any}): Promise<any> {
   console.log(`\n${payload.author}: ${payload.comment}`);
   return {ack: true};
 }
 
 function prepareNameListener(username: string) {
-  return async function nameListener({payload}: {payload: any}): Promise<any> {
+  return async function nameListener({payload}: {payload?: any}): Promise<any> {
     return {
       name: username
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {parse, serialize} from './serialization';
 import {is, identity, ifElse, map, curry, pipeP, lensProp, over} from 'ramda';
 import {RPCError} from './errors';
 export const IrisAMQP = _IrisAMQP;
-import {RegisterHandler, Iris, RegisterInput, EmitInput, CollectInput,RequestInput} from './types';
+import {RegisterActiveContext, RegisterHandler, Iris, RegisterInput, EmitInput, CollectInput,RequestInput} from './types';
 export * from './types';
 
 type F1<T, R> = (t: T) => R;
@@ -36,7 +36,7 @@ export default async function(opts: (IrisAMQPLibOpts & {
     parse
   );
 
-  const register: <T, R> (o: RegisterInput<T, R>) => Promise<void> = pipeP(
+  const register: <T, R> (o: RegisterInput<T, R>) => Promise<RegisterActiveContext> = pipeP(
     transformHandler,
     backend.register
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {RPCError} from './errors';
 export const IrisAMQP = _IrisAMQP;
 import {RegisterActiveContext, RegisterHandler, Iris, RegisterInput, EmitInput, CollectInput,RequestInput} from './types';
 export * from './types';
+export * from './utils';
 
 type F1<T, R> = (t: T) => R;
 export const toPromise = curry(function toPromise<T, R>(f: F1<T, R>, val: T) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,8 @@ import {RPCError} from './errors';
 export type RequestInput<T> = {pattern: string, payload?: T, timeout?: number};
 export type CollectInput<T> = RequestInput<T>;
 export type EmitInput<T> = {pattern: string, payload?: T};
-export type RegisterHandler<P, R> = (opts: {payload: (P | undefined), context: RegisterActiveContext}) => Promise<R>;
+export type RegisterHandlerInput<P> = {payload?: P, context: RegisterActiveContext};
+export type RegisterHandler<P, R> = (opts: RegisterHandlerInput<P>) => Promise<R>;
 export type RegisterInput<P, R> = {
   pattern: string;
   handler: RegisterHandler<P, R>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import {RPCError} from './errors';
 export type RequestInput<T> = {pattern: string, payload?: T, timeout?: number};
 export type CollectInput<T> = RequestInput<T>;
 export type EmitInput<T> = {pattern: string, payload?: T};
-export type RegisterHandler<P, R> = (opts: {payload: (P | undefined)}) => Promise<R>;
+export type RegisterHandler<P, R> = (opts: {payload: (P | undefined), context: RegisterActiveContext}) => Promise<R>;
 export type RegisterInput<P, R> = {
   pattern: string;
   handler: RegisterHandler<P, R>;
@@ -13,15 +13,22 @@ export type RegisterInput<P, R> = {
 
 export interface IrisBackend {
   request: (rq: RequestInput<Buffer>) => Promise<Buffer | void>;
-  register: (re: RegisterInput<Buffer, Buffer>) => Promise<void>;
+  register: (re: RegisterInput<Buffer, Buffer>) => Promise<RegisterActiveContext>;
   emit: (rq: EmitInput<Buffer>) => Promise<void>;
   collect: (rq: CollectInput<Buffer>) => Promise<(Buffer | RPCError)[]>;
+}
+
+export interface RegisterActiveContext {
+  pause: () => Promise<RegisterPausedContext>;
+}
+export interface RegisterPausedContext {
+  resume: () => Promise<RegisterActiveContext>;
 }
 
 export interface Iris {
   backend: IrisBackend;
   request: <I, O>(rq: RequestInput<I>) => Promise<O | void>;
-  register: <I, O>(re: RegisterInput<I, O>) => Promise<void>;
+  register: <I, O>(re: RegisterInput<I, O>) => Promise<RegisterActiveContext>;
   emit: <I>(rq: EmitInput<I>) => Promise<void>;
   collect: <I, O>(rq: CollectInput<I>) => Promise<(O | RPCError)[]>;
 }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -3,7 +3,7 @@ import {Test} from 'tape';
 import { stub, spy } from 'sinon';
 import {inject} from './utils';
 
-test.only('Inject tests', (t: Test) => {
+test('Inject tests', (t: Test) => {
   type A = {one: string};
   type B = {two: string};
   function f (ab: A & B) {

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,20 @@
+import * as test from 'tape';
+import {Test} from 'tape';
+import { stub, spy } from 'sinon';
+import {inject} from './utils';
+
+test.only('Inject tests', (t: Test) => {
+  type A = {one: string};
+  type B = {two: string};
+  function f (ab: A & B) {
+    return ab;
+  }
+
+  const f2 = inject<B, A, A&B>({args: {two: 'two'} as B, func: f});
+
+  const res = f2({one: 'one'});
+
+  t.deepEqual(res, {one: 'one', two: 'two'}, 'Injected should be equivalent as single object');
+
+  t.end();
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,15 @@
+export interface JSObj {[k: string]: any; }
+
+export type F<I, O> = (input: I) => O;
+
+export function inject<A extends JSObj, I extends JSObj, O>({
+    args,
+    func
+}: {
+    args: A,
+    func: F<I & A, O>
+}): F<I, O> {
+  return function(input: I): O {
+    return func(Object.assign({}, args, input));
+  };
+}


### PR DESCRIPTION
@mareq @DennisSchwartz 

This PR adds a new functionality that enables the temporal pause of ingestion for a specific registered handler. This is useful in conjunction with `emit` to emulate buffering.

There are two ways to access the new `pause` method:
  - Using the returned object from a new registration.
  ```ts
    const registerContext = await register({pattern: 'test', handler});
    registerContext.pause().then(() => console.log('Registration no longer accepts connections'))
  ```
  - Using the new `context` attribute injected to the handler
  ```ts
    register({pattern, async handler({payload, context}) {
      const pausedContext = await context.pause();
      // Not accepting messages here
      pausedContext.resume();
      // Iris will start calling the handler again.
    }})
  ```

It also includes a functional utility for handler injection allowing to lift a function from `(A&B) => O` to `(A) => (B) => O`

- [x] Definition of the functionality
- [x] Implementation of core functionality in AMQP
- [x] Test coverage of the feature
- [x] Inject utility function
- [x] Document functionality in the README